### PR TITLE
Switch publishing and repository configs to GitHub repository as primary

### DIFF
--- a/src/publishing.gradle
+++ b/src/publishing.gradle
@@ -11,11 +11,6 @@ java {
     withSourcesJar()
 }
 
-String cpmArtifactoryWriteUsername = System.getenv("CPM_ARTIFACTORY_WRITE_USERNAME") ?:
-        findProperty('cpmArtifactoryWriteUsername') ?: 'github'
-String cpmArtifactoryWritePassword = System.getenv("CPM_ARTIFACTORY_WRITE_PASSWORD") ?:
-        findProperty('cpmArtifactoryWritePassword') ?: 'jenkinspasswordplaceholder' // This is just a placeholder
-
 publishing {
 
     // destination repositories
@@ -23,15 +18,17 @@ publishing {
         mavenLocal() // to create 'publish___PublicationToMavenLocalRepository' tasks
 
         maven {
-            name = 'CPM' // to create 'publish___PublicationToCPMRepository' tasks
+            // Creates 'publish___PublicationToGHCPDRepository' task to publish artifacts into
+            //   `cellpointdigital/com.cellpointdigital` repository.
+            // This task is mentioned as an example, most likely you need to configure publishing at your own discretion.
+            name = 'GHCPD'
+            url = "https://maven.pkg.github.com/cellpointdigital/com.cellpointdigital"
             credentials {
-                username cpmArtifactoryWriteUsername
-                password cpmArtifactoryWritePassword
+                username = System.getenv("GITHUB_USERNAME")
+                password = System.getenv("PACKAGE_REGISTRY_WRITE_TOKEN")
             }
-            def releasesRepoUrl = "https://repo.t.cpm.ninja/artifactory/libs-release-local"
-            def snapshotsRepoUrl = "https://repo.t.cpm.ninja/artifactory/libs-snapshot-local"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
         }
+
     }
 
 }

--- a/src/repositories.gradle
+++ b/src/repositories.gradle
@@ -8,11 +8,32 @@ repositories {
     mavenLocal()
     mavenCentral()
 
+    String ghPackageReadUsername = System.getenv('GITHUB_USERNAME') ?: findProperty('ghArtifactoryReadUsername') ?: ''
+    String ghPackageReadToken = System.getenv('PACKAGE_REGISTRY_READ_TOKEN') ?: findProperty('ghArtifactoryReadToken') ?: ''
+    String ghUrl = 'https://maven.pkg.github.com/cellpointdigital/artifactory'
+    if (ghPackageReadUsername == '' || ghPackageReadToken == '') {
+        System.err.println('Environment variables GITHUB_USERNAME and PACKAGE_REGISTRY_READ_TOKEN are not set. ' +
+                'Dependencies from GitHub "' + ghUrl + '" will not be available!')
+    } else {
+        maven {
+            // https://cellpointdigital.atlassian.net/wiki/spaces/CEA/pages/18097274885/GitHub,
+            // GITHUB_USERNAME = 'userX' # Your GitHub usernames
+            // PACKAGE_REGISTRY_READ_TOKEN = 'ghp_xxxxx' # Your GitHub Personal Access Token (PAT) with "read:packages" permissions
+            url = ghUrl
+            credentials {
+                username = ghPackageReadUsername
+                password = ghPackageReadToken
+            }
+        }
+    }
+
+
     String cpmArtifactoryReadUsername = System.getenv("CPM_ARTIFACTORY_READ_USERNAME") ?:
             findProperty('cpmArtifactoryReadUsername') ?: 'cellpointmobileread'
     String cpmArtifactoryReadPassword = System.getenv("CPM_ARTIFACTORY_READ_PASSWORD") ?:
             findProperty('cpmArtifactoryReadPassword') ?: ''
 
+    // Deprecated
     maven {
         credentials {
             username = cpmArtifactoryReadUsername
@@ -21,6 +42,7 @@ repositories {
         url = "https://repo.t.cpm.ninja/artifactory/libs-release"
     }
 
+    // Deprecated
     maven {
         credentials {
             username = cpmArtifactoryReadUsername
@@ -29,19 +51,5 @@ repositories {
         url = "https://repo.t.cpm.ninja/artifactory/libs-snapshot"
     }
 
-    def ghPackageReadUsername = System.getenv("GITHUB_USERNAME")
-    def ghPackageToken = System.getenv("PACKAGE_REGISTRY_READ_TOKEN")
-    if (ghPackageReadUsername != null || ghPackageToken != null) {
-        maven {
-            // https://cellpointdigital.atlassian.net/wiki/spaces/CEA/pages/18097274885/GitHub,
-            // GITHUB_USERNAME = 'userX' # Your GitHub usernames
-            // PACKAGE_REGISTRY_READ_TOKEN = 'ghp_xxxxx' # Your GitHub Personal Access Token (PAT) with "read:packages" permissions
-            credentials {
-                username = ghPackageReadUsername
-                password = ghPackageToken
-            }
-            url = "https://maven.pkg.github.com/cellpointdigital"
-        }
-    }
 
 }


### PR DESCRIPTION
Updated publishing.gradle and repositories.gradle to utilize GitHub Package Registry for artifact publishing and dependencies. Deprecated older Artifactory configurations and replaced them with GitHub-specific credentials and URLs. Includes enhanced error-handling for missing environment variables.