### PR TITLE
repository related changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ apply from: "${addonsPath}/git.gradle"
 apply from: "${addonsPath}/compose.gradle" // optional
 ```
 
-3) assign properties with credentials in gradle.properties file:
+3) assign credentials to access CPD maven repositories:  
+
+ 3.1) for GitHub see instruction https://cellpointdigital.atlassian.net/wiki/spaces/CEA/pages/18097274885/GitHub
+
+ 3.2) for `repo.t.cpm.ninja/artifactory` (deprecated) add cpmArtifactoryReadPassword in gradle.properties or 
+   define CPM_ARTIFACTORY_READ_PASSWORD environment variable:    
 
 ```properties
 cpmArtifactoryReadPassword=xxxxxxxxxxx
@@ -152,14 +157,11 @@ Environment variables take precedence over properties.
 
 Used properties and environment variables:
 
-| property | env variable | descrition                                                                                       | default                                             |
-|-|-|-|-|
-|cpmArtifactoryReadUsername|CPM_ARTIFACTORY_READ_USERNAME| username for readonly access to common maven repository.| 'cellpointmobileread'                               | 
-|cpmArtifactoryReadPassword|CPM_ARTIFACTORY_READ_PASSWORD| password for readonly access to common maven repository.| ''                                                  |
-|cpmArtifactoryWriteUsername|CPM_ARTIFACTORY_WRITE_USERNAME| username for write access to common maven repository.| 'github'                                            |
-|cpmArtifactoryWritePassword|CPM_ARTIFACTORY_WRITE_PASSWORD| password for write access to common maven repository. <br/> This password usually assigned by CI | 'jenkinspasswordplaceholder' used as a placeholder |   
-
-
+| env variable | descrition                                                                       |
+|-|----------------------------------------------------------------------------------|
+|GITHUB_USERNAME| GitHub username, it is assigned by developers locally or by CI                   |
+|PACKAGE_REGISTRY_READ_TOKEN| classic GH token with 'packages:read' permission, assigned by developers or CI   |   
+|PACKAGE_REGISTRY_WRITE_TOKEN| classic GH token with 'packages:write' permission, it is assigned by CI usually  |
 
 ## working with submodule
 

--- a/src/repositories.gradle
+++ b/src/repositories.gradle
@@ -12,7 +12,7 @@ repositories {
     String ghPackageReadToken = System.getenv('PACKAGE_REGISTRY_READ_TOKEN') ?: findProperty('ghArtifactoryReadToken') ?: ''
     String ghUrl = 'https://maven.pkg.github.com/cellpointdigital/artifactory'
     if (ghPackageReadUsername == '' || ghPackageReadToken == '') {
-        System.err.println('Environment variables GITHUB_USERNAME and PACKAGE_REGISTRY_READ_TOKEN are not set. ' +
+        System.err.println('WARNING: Environment variables GITHUB_USERNAME and PACKAGE_REGISTRY_READ_TOKEN are not set. ' +
                 'Dependencies from GitHub "' + ghUrl + '" will not be available!')
     } else {
         maven {
@@ -28,28 +28,29 @@ repositories {
     }
 
 
+    // https://repo.t.cpm.ninja/artifactory is deprecated
     String cpmArtifactoryReadUsername = System.getenv("CPM_ARTIFACTORY_READ_USERNAME") ?:
             findProperty('cpmArtifactoryReadUsername') ?: 'cellpointmobileread'
     String cpmArtifactoryReadPassword = System.getenv("CPM_ARTIFACTORY_READ_PASSWORD") ?:
             findProperty('cpmArtifactoryReadPassword') ?: ''
-
-    // Deprecated
-    maven {
-        credentials {
-            username = cpmArtifactoryReadUsername
-            password = cpmArtifactoryReadPassword
+    if (cpmArtifactoryReadUsername == '' || cpmArtifactoryReadPassword == '') {
+        System.out.println('Username or password is not defined for "https://repo.t.cpm.ninja/artifactory". ' +
+                'Dependencies from it will not be available!')
+    } else {
+        maven {
+            credentials {
+                username = cpmArtifactoryReadUsername
+                password = cpmArtifactoryReadPassword
+            }
+            url = "https://repo.t.cpm.ninja/artifactory/libs-release"
         }
-        url = "https://repo.t.cpm.ninja/artifactory/libs-release"
-    }
-
-    // Deprecated
-    maven {
-        credentials {
-            username = cpmArtifactoryReadUsername
-            password = cpmArtifactoryReadPassword
+        maven {
+            credentials {
+                username = cpmArtifactoryReadUsername
+                password = cpmArtifactoryReadPassword
+            }
+            url = "https://repo.t.cpm.ninja/artifactory/libs-snapshot"
         }
-        url = "https://repo.t.cpm.ninja/artifactory/libs-snapshot"
     }
-
 
 }


### PR DESCRIPTION
Ensure that username and password for Artifactory are defined before attempting to use the repositories. This prevents potential build issues by notifying developers if credentials are missing. 